### PR TITLE
Updating installation for new questions asked in Symfony 2.5

### DIFF
--- a/knpu/installation.rst
+++ b/knpu/installation.rst
@@ -79,8 +79,7 @@ run ``ls vendor/``, you'll see that more and more things are popping up here.
 When that finishes, our terminal will become self-aware and start asking
 us configuration questions.
 
-If you're using Symfony 2.5 or higher, you may see a few questions that you
-*don't* see here. If it asks you:
+If it asks you:
 
     Would you like to use Symfony 3 directory structure?
 


### PR DESCRIPTION
Easy fix for the kind of annoying new questions during the 2.5 installation. We should probably re-record some audio for this. Ping @Leannapelham!

Video fix filename: `10-install-tweak`
