### PR TITLE
Update doctrine-lifecycle-callback.rst

### DIFF
--- a/knpu/episode3/doctrine-lifecycle-callback.rst
+++ b/knpu/episode3/doctrine-lifecycle-callback.rst
@@ -64,7 +64,7 @@ Now just put a ``PrePersist`` annotation above our function::
     public function prePersist()
     {
         if (!$this->getCreated()) {
-            $this->createdAt = new \DateTime();
+            $this->setCreatedAt(new \DateTime());
         }
     }
 


### PR DESCRIPTION
The point of this code is that you have to enable it using the PrePersist annotation.  I would assume inadvertently that the code was changed in the prePersist class method to set the class variable directly rather than call the setCreatedAt() method in the first example block.  I just fixed this for consistency and to remove the confusion.