### PR TITLE
"php bin/phpunit -c app" on Windows

### DIFF
--- a/knpu/episode2/testing.rst
+++ b/knpu/episode2/testing.rst
@@ -121,7 +121,7 @@ option:
     
     .. code-block:: bash
     
-        php vendor/phpunit/phpunit/phpunit -c app
+        bin\phpunit -c app
 
 This tells PHPUnit to look for a configuration file in the ``app/`` directory.
 And hey! There's a ``phpunit.xml.dist`` file there already for it to read. This


### PR DESCRIPTION
It works on windows without the starting php, because it is added in the phpunit.bat.
Use only: bin\phpunit -c app
