### PR TITLE
Fix broken link address

### DIFF
--- a/knpu/episode3/json-response.rst
+++ b/knpu/episode3/json-response.rst
@@ -122,5 +122,5 @@ JSON!
 
     The JSON is pretty in my browser because of the `JSONView`_ Chrome extension.
 
-.. _`REST Series`: knpuniversity.com/screencast/rest
+.. _`REST Series`: https://knpuniversity.com/screencast/symfony-rest
 .. _`JSONView`: https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc


### PR DESCRIPTION
I think a link to the Symfony REST tutorial is more relevant in this case. Btw, there is already another link to REST in that tutorial description.